### PR TITLE
feat: SSMLを独立したファイルタイプとして追加

### DIFF
--- a/project/backend/api.py
+++ b/project/backend/api.py
@@ -145,8 +145,9 @@ async def get_project_topics(project_id: int):
             topic_data['has_html'] = bool(topic_data.get('has_html'))
             topic_data['has_txt'] = bool(topic_data.get('has_txt'))
             topic_data['has_mp3'] = bool(topic_data.get('has_mp3'))
+            topic_data['has_ssml'] = bool(topic_data.get('has_ssml'))
 
-            # ステータス計算
+            # ステータス計算（SSMLは進捗に影響しない）
             if topic_data['has_html'] and topic_data['has_txt'] and topic_data['has_mp3']:
                 topic_data['status'] = 'completed'
                 completed += 1

--- a/project/frontend/index.html
+++ b/project/frontend/index.html
@@ -786,6 +786,15 @@
                                             >
                                                 {{ topic.has_mp3 ? '✓' : '□' }}
                                             </span>
+                                            <span
+                                                :class="[
+                                                    'w-8 h-8 flex items-center justify-center rounded text-sm',
+                                                    topic.has_ssml ? 'bg-purple-100 text-purple-700' : 'bg-gray-100 text-gray-400'
+                                                ]"
+                                                title="SSML"
+                                            >
+                                                {{ topic.has_ssml ? '✓' : '□' }}
+                                            </span>
                                         </div>
                                     </div>
                                 </div>
@@ -847,6 +856,15 @@
                                             title="MP3"
                                         >
                                             {{ topic.has_mp3 ? '✓' : '□' }}
+                                        </span>
+                                        <span
+                                            :class="[
+                                                'w-8 h-8 flex items-center justify-center rounded text-sm',
+                                                topic.has_ssml ? 'bg-purple-100 text-purple-700' : 'bg-gray-100 text-gray-400'
+                                            ]"
+                                            title="SSML"
+                                        >
+                                            {{ topic.has_ssml ? '✓' : '□' }}
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- SSMLファイル（Google Cloud TTS用）を独立したファイルタイプカテゴリとして追加
- Gemini 2.5 Flash TTSは通常のTXTを使用、Google Cloud TTSはSSML（xxx_ssml.txt）を使用するため分離
- SSMLはオプショナル扱い（SSML=0でも進捗には影響しない）

## Changes
- **database.py**: `has_ssml`, `ssml_hash`カラムをtopicsテーブルに追加
- **scanner.py**: 
  - SSMLファイル検出ロジック追加（xxx_ssml.txtパターン）
  - `_ssml`で終わるファイルをスキップしてSSMLとTXTを分離
  - ファイルパターンを`\d+[-_]\d+`に拡張（`1-1`と`1_1`両方に対応）
- **api.py**: `has_ssml`のboolean変換を追加
- **index.html**: トピック詳細にSSMLインジケーター追加（紫色）

## Test plan
- [x] SSMLファイルが正しく検出されることを確認（GitとGithub入門-cloud-tts: 33トピック全てSSML検出）
- [x] TXT数がSSMLと重複カウントされないことを確認（TXT=33, SSML=33で分離）
- [x] 進捗計算にSSMLが含まれないことを確認
- [x] フロントエンドでSSMLカラムが表示されることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)