### PR TITLE
feat: add publication status (free/paid/private) to projects

### DIFF
--- a/project/backend/api.py
+++ b/project/backend/api.py
@@ -454,7 +454,7 @@ async def delete_tts_engine(tts_engine_id: int):
 
 @router.put("/projects/{project_id}/settings")
 async def update_project_settings(project_id: int, data: dict):
-    """プロジェクト設定更新（納品先・音声変換エンジン）"""
+    """プロジェクト設定更新（納品先・音声変換エンジン・公開状態）"""
     try:
         db = await get_database()
 
@@ -465,8 +465,13 @@ async def update_project_settings(project_id: int, data: dict):
 
         destination_id = data.get('destination_id')
         tts_engine_id = data.get('tts_engine_id')
+        publication_status = data.get('publication_status')
 
-        await db.update_project_settings(project_id, destination_id, tts_engine_id)
+        # publication_statusの値を検証
+        if publication_status is not None and publication_status not in ('free', 'paid', 'private'):
+            raise HTTPException(status_code=400, detail="Invalid publication_status. Must be 'free', 'paid', or 'private'")
+
+        await db.update_project_settings(project_id, destination_id, tts_engine_id, publication_status)
 
         # 更新後のプロジェクトを取得
         updated_project = await db.get_project(project_id)

--- a/project/frontend/index.html
+++ b/project/frontend/index.html
@@ -469,13 +469,13 @@
                                 </button>
                             </div>
                             <!-- 設定ドロップダウン -->
-                            <div class="flex gap-2 text-xs" @click.stop>
+                            <div class="flex flex-wrap gap-2 text-xs" @click.stop>
                                 <select
                                     :value="project.destination_id || ''"
                                     @change="onDestinationChange(project.id, $event.target.value)"
-                                    class="flex-1 px-2 py-1 border rounded text-xs"
+                                    class="flex-1 px-2 py-1 border rounded text-xs min-w-0"
                                 >
-                                    <option value="">📦 納品先を選択</option>
+                                    <option value="">📦 納品先</option>
                                     <option v-for="dest in destinations" :key="dest.id" :value="dest.id">
                                         {{ dest.name }}
                                     </option>
@@ -483,12 +483,21 @@
                                 <select
                                     :value="project.tts_engine_id || ''"
                                     @change="onTtsEngineChange(project.id, $event.target.value)"
-                                    class="flex-1 px-2 py-1 border rounded text-xs"
+                                    class="flex-1 px-2 py-1 border rounded text-xs min-w-0"
                                 >
-                                    <option value="">🔊 音声変換を選択</option>
+                                    <option value="">🔊 音声</option>
                                     <option v-for="tts in ttsEngines" :key="tts.id" :value="tts.id">
                                         {{ tts.name }}
                                     </option>
+                                </select>
+                                <select
+                                    :value="project.publication_status || 'private'"
+                                    @change="onPublicationStatusChange(project.id, $event.target.value)"
+                                    class="flex-1 px-2 py-1 border rounded text-xs min-w-0"
+                                >
+                                    <option value="private">🔒 非公開</option>
+                                    <option value="free">🆓 無料公開</option>
+                                    <option value="paid">💰 有料公開</option>
                                 </select>
                             </div>
                         </div>
@@ -498,14 +507,15 @@
                 <!-- リスト表示 -->
                 <div v-else class="bg-white rounded-lg shadow overflow-hidden overflow-x-auto">
                     <!-- リストヘッダー -->
-                    <div class="grid grid-cols-16 gap-2 px-4 py-3 bg-gray-50 border-b text-sm font-medium text-gray-500 min-w-[1000px]">
-                        <div class="col-span-3">プロジェクト名</div>
+                    <div class="grid grid-cols-16 gap-2 px-4 py-3 bg-gray-50 border-b text-sm font-medium text-gray-500 min-w-[1100px]">
+                        <div class="col-span-2">プロジェクト名</div>
                         <div class="col-span-2 text-center">進捗</div>
                         <div class="col-span-1 text-center">HTML</div>
                         <div class="col-span-1 text-center">TXT</div>
                         <div class="col-span-1 text-center">MP3</div>
                         <div class="col-span-2 text-center">納品先</div>
-                        <div class="col-span-3 text-center">音声変換</div>
+                        <div class="col-span-2 text-center">音声変換</div>
+                        <div class="col-span-2 text-center">公開状態</div>
                         <div class="col-span-2 text-center">トピック</div>
                         <div class="col-span-1 text-center">状態</div>
                     </div>
@@ -515,9 +525,9 @@
                         v-for="project in sortedFilteredProjects"
                         :key="project.id"
                         @click="selectProject(project)"
-                        class="grid grid-cols-16 gap-2 px-4 py-3 border-b hover:bg-blue-50 cursor-pointer transition-colors list-item-hover min-w-[1000px]"
+                        class="grid grid-cols-16 gap-2 px-4 py-3 border-b hover:bg-blue-50 cursor-pointer transition-colors list-item-hover min-w-[1100px]"
                     >
-                        <div class="col-span-3 flex items-center gap-2">
+                        <div class="col-span-2 flex items-center gap-2">
                             <span class="font-medium text-gray-800 truncate" :title="project.name">
                                 {{ project.name }}
                             </span>
@@ -562,7 +572,7 @@
                                 </option>
                             </select>
                         </div>
-                        <div class="col-span-3 text-center" @click.stop>
+                        <div class="col-span-2 text-center" @click.stop>
                             <select
                                 :value="project.tts_engine_id || ''"
                                 @change="onTtsEngineChange(project.id, $event.target.value)"
@@ -572,6 +582,17 @@
                                 <option v-for="tts in ttsEngines" :key="tts.id" :value="tts.id">
                                     {{ tts.name }}
                                 </option>
+                            </select>
+                        </div>
+                        <div class="col-span-2 text-center" @click.stop>
+                            <select
+                                :value="project.publication_status || 'private'"
+                                @change="onPublicationStatusChange(project.id, $event.target.value)"
+                                class="w-full px-2 py-1 border rounded text-xs"
+                            >
+                                <option value="private">🔒 非公開</option>
+                                <option value="free">🆓 無料</option>
+                                <option value="paid">💰 有料</option>
                             </select>
                         </div>
                         <div class="col-span-2 text-center text-sm text-gray-600">

--- a/project/frontend/js/app.js
+++ b/project/frontend/js/app.js
@@ -295,6 +295,38 @@ const app = createApp({
             }
         }
 
+        // 公開状態の変更
+        function onPublicationStatusChange(projectId, status) {
+            const project = projects.value.find(p => p.id === projectId);
+            if (project) {
+                updateProjectSettings(projectId, {
+                    destination_id: project.destination_id,
+                    tts_engine_id: project.tts_engine_id,
+                    publication_status: status || 'private'
+                });
+            }
+        }
+
+        // 公開状態のラベル取得
+        function getPublicationStatusLabel(status) {
+            const labels = {
+                'free': '🆓 無料公開',
+                'paid': '💰 有料公開',
+                'private': '🔒 非公開'
+            };
+            return labels[status] || labels['private'];
+        }
+
+        // 公開状態のバッジクラス取得
+        function getPublicationStatusClass(status) {
+            const classes = {
+                'free': 'bg-green-100 text-green-700',
+                'paid': 'bg-yellow-100 text-yellow-700',
+                'private': 'bg-gray-100 text-gray-700'
+            };
+            return classes[status] || classes['private'];
+        }
+
         // ========== マスター管理メソッド ==========
 
         // 納品先の追加
@@ -662,6 +694,9 @@ const app = createApp({
             // プロジェクト設定
             onDestinationChange,
             onTtsEngineChange,
+            onPublicationStatusChange,
+            getPublicationStatusLabel,
+            getPublicationStatusClass,
 
             // マスター管理
             addDestination,


### PR DESCRIPTION
## Summary
- プロジェクトに公開状態（無料公開/有料公開/非公開）フラグを追加

## Changes
- `database.py`: publication_status カラム追加（CHECK制約付き）+ マイグレーション
- `api.py`: 設定更新APIで publication_status を処理
- `index.html`: カード表示・リスト表示に公開状態ドロップダウン追加
- `app.js`: 公開状態変更ハンドラー + ラベル表示関数追加

## Test plan
- [x] API テスト済み（curl で publication_status 更新確認）
- [ ] ブラウザでドロップダウンから公開状態を変更
- [ ] 画面リロード後も設定が保持されていることを確認

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)