### PR TITLE
feat: add publication status master management

### DIFF
--- a/project/frontend/index.html
+++ b/project/frontend/index.html
@@ -491,13 +491,14 @@
                                     </option>
                                 </select>
                                 <select
-                                    :value="project.publication_status || 'private'"
+                                    :value="project.publication_status_id || ''"
                                     @change="onPublicationStatusChange(project.id, $event.target.value)"
                                     class="flex-1 px-2 py-1 border rounded text-xs min-w-0"
                                 >
-                                    <option value="private">🔒 非公開</option>
-                                    <option value="free">🆓 無料公開</option>
-                                    <option value="paid">💰 有料公開</option>
+                                    <option value="">📋 公開状態</option>
+                                    <option v-for="status in publicationStatuses" :key="status.id" :value="status.id">
+                                        {{ status.name }}
+                                    </option>
                                 </select>
                             </div>
                         </div>
@@ -586,13 +587,14 @@
                         </div>
                         <div class="col-span-2 text-center" @click.stop>
                             <select
-                                :value="project.publication_status || 'private'"
+                                :value="project.publication_status_id || ''"
                                 @change="onPublicationStatusChange(project.id, $event.target.value)"
                                 class="w-full px-2 py-1 border rounded text-xs"
                             >
-                                <option value="private">🔒 非公開</option>
-                                <option value="free">🆓 無料</option>
-                                <option value="paid">💰 有料</option>
+                                <option value="">-</option>
+                                <option v-for="status in publicationStatuses" :key="status.id" :value="status.id">
+                                    {{ status.name }}
+                                </option>
                             </select>
                         </div>
                         <div class="col-span-2 text-center text-sm text-gray-600">
@@ -939,6 +941,17 @@
                     >
                         🔊 音声変換マスター
                     </button>
+                    <button
+                        @click="settingsTab = 'publication-statuses'"
+                        :class="[
+                            'px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+                            settingsTab === 'publication-statuses'
+                                ? 'bg-green-500 text-white'
+                                : 'bg-white text-gray-600 hover:bg-gray-100'
+                        ]"
+                    >
+                        📋 公開状態マスター
+                    </button>
                 </div>
 
                 <!-- 納品先マスター -->
@@ -1110,6 +1123,94 @@
                                 @click="addTtsEngine"
                                 :disabled="!newItemName.trim()"
                                 class="px-4 py-2 bg-indigo-500 text-white rounded-lg text-sm hover:bg-indigo-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+                            >
+                                ＋ 追加
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 公開状態マスター -->
+                <div v-else-if="settingsTab === 'publication-statuses'" class="bg-white rounded-lg shadow">
+                    <div class="p-6 border-b">
+                        <h3 class="text-lg font-semibold text-gray-800 flex items-center gap-2">
+                            📋 公開状態マスター
+                            <span class="text-sm font-normal text-gray-500">({{ publicationStatuses.length }}件)</span>
+                        </h3>
+                        <p class="text-sm text-gray-500 mt-1">プロジェクトの公開状態を管理します</p>
+                    </div>
+
+                    <!-- 一覧 -->
+                    <div class="divide-y">
+                        <div
+                            v-for="status in publicationStatuses"
+                            :key="status.id"
+                            class="flex items-center justify-between p-4 hover:bg-gray-50"
+                        >
+                            <div class="flex items-center gap-3">
+                                <span class="text-gray-400 text-sm">{{ status.display_order || '-' }}</span>
+                                <template v-if="editingItem && editingItem.id === status.id">
+                                    <input
+                                        v-model="editingItem.name"
+                                        type="text"
+                                        class="px-2 py-1 border rounded text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
+                                        @keyup.enter="saveEditing"
+                                        @keyup.escape="cancelEditing"
+                                    >
+                                </template>
+                                <template v-else>
+                                    <span class="font-medium text-gray-800">{{ status.name }}</span>
+                                </template>
+                            </div>
+                            <div class="flex items-center gap-2">
+                                <template v-if="editingItem && editingItem.id === status.id">
+                                    <button
+                                        @click="saveEditing"
+                                        class="px-3 py-1 bg-green-500 text-white text-sm rounded hover:bg-green-600"
+                                    >
+                                        保存
+                                    </button>
+                                    <button
+                                        @click="cancelEditing"
+                                        class="px-3 py-1 bg-gray-100 text-gray-600 text-sm rounded hover:bg-gray-200"
+                                    >
+                                        キャンセル
+                                    </button>
+                                </template>
+                                <template v-else>
+                                    <button
+                                        @click="startEditing(status)"
+                                        class="px-3 py-1 bg-gray-100 text-gray-600 text-sm rounded hover:bg-gray-200"
+                                        title="編集"
+                                    >
+                                        ✏️
+                                    </button>
+                                    <button
+                                        @click="deletePublicationStatus(status.id)"
+                                        class="px-3 py-1 bg-red-100 text-red-600 text-sm rounded hover:bg-red-200"
+                                        title="削除"
+                                    >
+                                        🗑️
+                                    </button>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- 新規追加 -->
+                    <div class="p-6 border-t bg-gray-50">
+                        <div class="flex gap-2">
+                            <input
+                                v-model="newItemName"
+                                type="text"
+                                placeholder="新しい公開状態の名前（例: 🆓 無料公開）"
+                                class="flex-1 px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
+                                @keyup.enter="addPublicationStatus"
+                            >
+                            <button
+                                @click="addPublicationStatus"
+                                :disabled="!newItemName.trim()"
+                                class="px-4 py-2 bg-green-500 text-white rounded-lg text-sm hover:bg-green-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
                             >
                                 ＋ 追加
                             </button>

--- a/project/frontend/js/api.js
+++ b/project/frontend/js/api.js
@@ -265,6 +265,39 @@ const API = {
         return await this.delete(`/tts-engines/${id}`);
     },
 
+    // ========== 公開状態マスターAPI ==========
+
+    /**
+     * 公開状態一覧取得
+     */
+    async getPublicationStatuses() {
+        return await this.get('/publication-statuses');
+    },
+
+    /**
+     * 公開状態作成
+     */
+    async createPublicationStatus(data) {
+        this.clearCache('/publication-statuses');
+        return await this.post('/publication-statuses', data);
+    },
+
+    /**
+     * 公開状態更新
+     */
+    async updatePublicationStatus(id, data) {
+        this.clearCache('/publication-statuses');
+        return await this.put(`/publication-statuses/${id}`, data);
+    },
+
+    /**
+     * 公開状態削除
+     */
+    async deletePublicationStatus(id) {
+        this.clearCache('/publication-statuses');
+        return await this.delete(`/publication-statuses/${id}`);
+    },
+
     // ========== ヘルスチェック ==========
 
     /**


### PR DESCRIPTION
## Summary
- 公開状態をマスターデータとして管理できるようにしました
- 設定画面に「公開状態マスター」タブを追加

## Changes
- `database.py`: publication_statuses テーブル追加、publication_status_id カラムへの移行
- `api.py`: 公開状態CRUD APIエンドポイント追加
- `api.js`: 公開状態APIメソッド追加
- `app.js`: 公開状態管理機能追加
- `index.html`: 設定画面に公開状態タブ追加、ドロップダウンを動的に変更

## Initial Data
- 🔒 非公開
- 🆓 無料公開
- 💰 有料公開

## Test plan
- [x] API テスト済み（publication_statuses CRUD）
- [x] プロジェクト設定更新 with publication_status_id
- [ ] ブラウザで設定画面の公開状態マスター編集
- [ ] プロジェクトカード/リストの公開状態ドロップダウン動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)